### PR TITLE
chore(.github): bump `golangci/golangci-lint-action`

### DIFF
--- a/.github/workflows/ci-pre-merge.yml
+++ b/.github/workflows/ci-pre-merge.yml
@@ -37,7 +37,7 @@ jobs:
           go-version: oldstable
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           args: --timeout=10m
           only-new-issues: true


### PR DESCRIPTION
necessary to switch to Go 1.25